### PR TITLE
Added ability to pass additional input variables to tracking output.

### DIFF
--- a/config/config_era5_vorticity.yml
+++ b/config/config_era5_vorticity.yml
@@ -1,5 +1,5 @@
 ---
-# ERA5 vorticity tracking configuration file
+# ERA5 vorticity anomaly tracking configuration file
 
 # Identify features to track
 run_idfeature: True
@@ -9,34 +9,41 @@ run_tracksingle: True
 run_gettracks: True
 # Calculate feature statistics
 run_trackstats: True
+# Link merge/split tracks
+run_mergesplit: True
 # Map tracking to pixel files
 run_mapfeature: True
+
 # Start/end date and time
-startdate: '20120625.0000'
-enddate: '20120630.2300'
+startdate: '20100501.0000'
+enddate: '20100502.2300'
 
 # Parallel processing set up
 # run_parallel: 1 (local cluster), 2 (Dask MPI)
 run_parallel: 1
-nprocesses: 20  # Number of processors to use if run_parallel=1
+nprocesses: 32  # Number of processors to use if run_parallel=1
 
-databasename: ERA5_VortPW_
+databasename: ERA5_bandpass_wl500to2500km_perlat_vort_sf_
+#databasename: ERA5_SFvortPV_
 # Specify date/time string format in the file name
 # E.g., radar_20181101.011503.nc --> yyyymodd.hhmmss
 # E.g., wrfout_2018-11-01_01:15:00 --> yyyy-mo-dd_hh:mm:ss
 time_format: 'yyyy-mo-dd'
+
 # Input files directory
-clouddata_path: '/global/project/projectdirs/m1867/jmarquis/era5/smooth_test/'
+clouddata_path: '/pscratch/sd/j/jmarquis/ERA5_waccem/Bandpassed/'
+
 # Working directory for the tracking data
-root_path: '/global/cscratch1/sd/feng045/waccem/ERA5_VOR/'
+root_path: '/pscratch/sd/f/feng045/demo/general_tracking/Bandpassed/'
+# root_path: '/pscratch/sd/j/jmarquis/ERA5_waccem/Bandpassed/'
 # Working sub-directory names
-tracking_path_name: 'tracking'
-stats_path_name: 'stats'
+tracking_path_name: 'vtracking'
+stats_path_name: 'vortstats'
 pixel_path_name: 'vortracking'
 
 # Specify types of feature being tracked
 # This adds additional feature-specific statistics to be computed
-feature_type: 'vorticity'
+feature_type: 'generic'
 
 # Specify data structure
 datatimeresolution: 1.0     # hours
@@ -44,16 +51,31 @@ pixel_radius: 25.0      # km
 x_dimname: 'longitude'
 y_dimname: 'latitude'
 time_dimname: 'time'
-field_varname: 'VOR600s10'
-vor_thresh: 0.00004  # Min vorticity threshold
-min_npix: 4   # Min number of pixels to define a feature
+time_coordname: 'time'
+x_coordname: 'longitude'
+y_coordname: 'latitude'
+field_varname: 'VOR600_bpf_sm7pt'
+
+# Feature detection parameters
+label_method: 'skimage.watershed'
+# peak_local_max params:
+plm_min_distance: 15   # min_distance - distance buffer between maxima; num grid points
+plm_exclude_border: 5   # exclude_border - distance buffer between maxima and the domain sides; num grid points
+plm_threshold_abs: 0   # threshold_abs - minimum magnitude of PSI' required to define a maxima
+# watershed params:
+cont_thresh: 0.00002   # PSI' contour defining outermost of flood-filled object area
+compa: 0    #"compactness factor" - (how much you'll let a flood fill spread into a neighbor's domain. Zero or < 100 seemed ok.)
+
+# field_thresh: [1.6, 1000]  # variable thresholds
+min_size: 10000.0   # Min area to define a feature (km^2)
+R_earth: 6378.0  # Earth radius (km)
 
 # Tracking parameters
-timegap: 2.0           # hour
+timegap: 3.0           # hour
 othresh: 0.3           # overlap percentage threshold
 maxnclouds: 100       # Maximum number of features in one snapshot
 nmaxlinks: 10          # Maximum number of overlaps that any single feature can be linked to
-duration_range: [2, 300]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range: [6, 800]   # A vector [minlength,maxlength] to specify the duration range for the tracks
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1
@@ -62,6 +84,12 @@ remove_shorttracks: 1
 trackstats_dense_netcdf: 1
 # Minimum time difference threshold to match track stats with cloudid pixel files
 match_pixel_dt_thresh: 60.0  # seconds
+
+# Link merge/split parameters to main tracks
+maintrack_area_thresh: 10000  # [km^2] Main track area threshold
+maintrack_lifetime_thresh: 6  # [hour] Main track duration threshold
+split_duration: 6  # [hour] Split tracks <= this length is linked to the main tracks
+merge_duration: 6  # [hour] Merge tracks <= this length is linked to the main tracks
 
 # Define tracked feature variable names
 feature_varname: 'feature_number'
@@ -72,4 +100,18 @@ featuresize_varname: 'npix_feature'
 tracks_dimname: 'tracks'
 times_dimname: 'times'
 fillval: -9999
-pixeltracking_filebase: 'vortracks_'
+# Output file base names
+finalstats_filebase: 'trackstats_final_'
+pixeltracking_filebase: 'vorbpf_tracks_'
+
+# List of variable names to pass from input to tracking output data
+pass_varname:
+  - 'U600'
+  - 'V600'
+  - 'U600_bpf'
+  - 'V600_bpf'
+  - 'VOR600'
+  - 'VOR600_bpf'
+  - 'VOR600_bpf_sm7pt'
+  - 'SFp600'
+  - 'SFp600_bpf'

--- a/pyflextrkr/idfeature_generic.py
+++ b/pyflextrkr/idfeature_generic.py
@@ -3,8 +3,8 @@ import sys
 import numpy as np
 import time
 import xarray as xr
+import pandas as pd
 import logging
-from datetime import datetime
 from scipy.ndimage import label
 from pyflextrkr.ftfunctions import sort_renumber, skimage_watershed
 
@@ -31,14 +31,19 @@ def idfeature_generic(
     feature_varname = config.get("feature_varname", "feature_number")
     nfeature_varname = config.get("nfeature_varname", "nfeatures")
     featuresize_varname = config.get("featuresize_varname", "npix_feature")
-    x_dimname = config.get("x_dimname", "longitude")
-    y_dimname = config.get("y_dimname", "latitude")
-    time_dimname = config.get("time", "time")
+    x_dimname = config.get("x_dimname")
+    y_dimname = config.get("y_dimname")
+    z_dimname = config.get("z_dimname", None)
+    time_dimname = config.get("time_dimname")
+    time_coordname = config.get("time_coordname")
+    x_coordname = config.get("x_coordname")
+    y_coordname = config.get("y_coordname")
     field_varname = config.get("field_varname")
     field_thresh = config.get("field_thresh")
     min_size = config.get("min_size")
     label_method = config.get("label_method", "ndimage.label")
     R_earth = config.get("R_earth")
+    pass_varname = config.get("pass_varname", None)
     fillval = config["fillval"]
 
     # Get min/max field thresholds
@@ -47,47 +52,45 @@ def idfeature_generic(
 
     # Read input data
     ds = xr.open_dataset(input_filename, mask_and_scale=False)
-    # Get number of dimensions
-    ndims = len(ds.dims)
-    # Reorder data dimensions & drop extra dimensions
-    if ndims == 2:
-        # Reorder dimensions: [y, x]
-        ds = ds.transpose(y_dimname, x_dimname)
-    elif ndims == 3:
-        # Reorder dimensions: [time, y, x]
-        ds = ds.transpose(time_dimname, y_dimname, x_dimname)
-    elif ndims >= 4:
-        # Get dimension names from the file
-        dims_file = []
-        for key in ds.dims: dims_file.append(key)
-        # Find extra dimensions beyond [time, y, x]
-        dims_keep = [time_dimname, y_dimname, x_dimname]
-        dims_drop = list(set(dims_file) - set(dims_keep))
-        # Drop extra dimensions, reorder to [time, y, x]
-        ds = ds.drop_dims(dims_drop).transpose(time_dimname, y_dimname, x_dimname)
+    # Get dimension names from the file
+    dims_file = []
+    for key in ds.dims: dims_file.append(key)
+    # Find extra dimensions beyond [time, z, y, x]
+    dims_keep = [time_dimname, z_dimname, y_dimname, x_dimname]
+    dims_drop = list(set(dims_file) - set(dims_keep))
+    # Reorder Dataset dimensions
+    if z_dimname is not None:
+        # Drop extra dimensions, reorder to [time, z, y, x]
+        ds = ds.drop_dims(dims_drop).transpose(
+            time_dimname, z_dimname, y_dimname, x_dimname, missing_dims='ignore',
+        )
     else:
-        logger.error(f"ERROR: Unexpected input data dimensions: {ds.dims}")
-        logger.error("Must add codes to handle reading.")
-        logger.error("Tracking will now exit.")
-        sys.exit()
+        # Drop extra dimensions, reorder to [time, y, x]
+        ds = ds.drop_dims(dims_drop).transpose(
+            time_dimname, y_dimname, x_dimname, missing_dims='ignore',
+        )
 
     # Read data variables
     ntimes = ds.dims[time_dimname]
-    x_coord = ds.coords[x_dimname]
-    y_coord = ds.coords[y_dimname]
-    time_decode = ds[time_dimname]
+    x_coord = ds.coords[x_coordname]
+    y_coord = ds.coords[y_coordname]
+    time_decode = ds[time_coordname]
     field_var = ds[field_varname]
     ds.close()
 
-    # Create 2D lat/lon grid
-    lon2d, lat2d = np.meshgrid(x_coord, y_coord)
-    lon2d = lon2d.astype(np.float32)
-    lat2d = lat2d.astype(np.float32)
+    # Check coordinate dimensions
+    if (y_coord.ndim == 1) | (x_coord.ndim == 1):
+        # Mesh 1D coordinate into 2D
+        lon2d, lat2d = np.meshgrid(x_coord, y_coord)
+        lon2d = lon2d.astype(np.float32)
+        lat2d = lat2d.astype(np.float32)
+    elif (y_coord.ndim == 2) | (x_coord.ndim == 2):
+        lon2d = x_coord.data
+        lat2d = y_coord.data
+
     # Calculate mean lat/lon grid distance (assuming fix grid size)
-    # dlon = np.array(x_coord[2] - x_coord[1])
-    # dlat = np.array(y_coord[2] - y_coord[1])
-    dlon = np.mean(np.abs(np.diff(x_coord)))
-    dlat = np.mean(np.abs(np.diff(y_coord)))
+    dlon = np.mean(np.abs(np.diff(lon2d, axis=1)))
+    dlat = np.mean(np.abs(np.diff(lat2d, axis=0)))
 
     # Calculate grid cell area (simple cosine adjustment)
     grid_area = (R_earth**2) * np.cos(np.deg2rad(lat2d)) * np.deg2rad(dlat) * np.deg2rad(dlon)
@@ -106,19 +109,27 @@ def idfeature_generic(
     # Compute grid_area
     # grid_area = dx_ * dy_
 
+    if pass_varname is not None:
+        # Find the common variable names between the dataset and the list
+        pass_varname = set(ds.data_vars) & set(pass_varname)
+        # Subset the input dataset
+        ds_pass = ds[pass_varname]
+
     # Loop over each time
     for tt in range(0, ntimes):
         # Get data at this time
-        iTime = ds.indexes['time'][tt]
+        iTime = time_decode[tt]
         fvar = field_var.data[tt,:,:]
 
-        # Label feature with simple threshold & connectivity method
+        # Label feature
+        # Simple threshold & connectivity method
         if label_method == 'ndimage.label':
             var_number, nblobs = label((field_thresh_min < fvar) & (fvar < field_thresh_max))
             param_dict = {
                 'field_thresh': field_thresh,
             }
 
+        # Watershed
         if label_method == 'skimage.watershed':
             var_number, param_dict = skimage_watershed(fvar, config)
 
@@ -128,10 +139,11 @@ def idfeature_generic(
         # Get number of features
         nfeatures = np.nanmax(feature_mask)
 
-        # Get date/time and make output filename
-        file_basetime = np.array([(np.datetime64(iTime).item() - datetime(1970, 1, 1, 0, 0, 0)).total_seconds()])
-        file_datestring = time_decode[tt].dt.strftime("%Y%m%d").item()
-        file_timestring = time_decode[tt].dt.strftime("%H%M%S").item()
+        # Convert to basetime (i.e., Epoch time)
+        file_basetime = np.array([(pd.to_datetime(iTime.data) - pd.Timestamp('1970-01-01T00:00:00')).total_seconds()])
+        # Convert to strings
+        file_datestring = iTime.dt.strftime("%Y%m%d").item()
+        file_timestring = iTime.dt.strftime("%H%M%S").item()
         cloudid_outfile = (
             config["tracking_outpath"] +
             config["cloudid_filebase"] +
@@ -193,6 +205,14 @@ def idfeature_generic(
         # Add each parameter to global attribute dictionary
         for key in param_dict:
             gattr_dict[key] = param_dict[key]
+
+        # Add pass out variables to the output variable dictionary
+        if pass_varname is not None:
+            # Subset the time from the pass out Dataset
+            dsp = ds_pass.isel({time_coordname:tt})
+            # Loop over each pass out variable list
+            for ivar in pass_varname:
+                var_dict[ivar] = (["time", "lat", "lon"], np.expand_dims(dsp[ivar].data, 0), dsp[ivar].attrs)
 
         # Define xarray dataset
         dsout = xr.Dataset(var_dict, coords=coord_dict, attrs=gattr_dict)


### PR DESCRIPTION
1. Added an optional list of variables in the config file for generic feature tracking: pass_varname. The variables in the list that exist in the input data will be passed to the tracking pixel-level output data.

2. Update: pyflextrkr/idfeature_generic.py
- Added codes to pass variables from input files to output files.
- Added additional coordinate names and removed default dimension names when reading in from config. These names must be specified in the config to avoid confusion.
- Updated codes to better handle reordering input dataset dimensions, time coordinates.

3. Updated example vorticity tracking config: config/config_era5_vorticity.yml.