### PR TITLE
Bug fix in MCS small merge/split number recording.

### DIFF
--- a/config/concat_mcs_idealized_masks.sh
+++ b/config/concat_mcs_idealized_masks.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+###############################################################################################
+# This script combines individual MCS pixel mask files from idealized tracking to
+# a single file, and renames variables/dimensions.
+###############################################################################################
+
+# Specify directory for the demo data
+# There are a total of 4 tests (e.g., test1, test2, test3, test4)
+test_name='test1'
+
+# Test file directory
+dir_demo='/Users/feng045/data/demo/mcs_tbpf/idealized/'${test_name}'/'
+# Test MCS pixel mask directory
+out_dirname=${dir_demo}'/mcstracking/20200101.0000_20200103.0000/'
+# Output file directory
+out_filename='MCS_mask_idealized_'${test_name}'_Feng.nc'
+
+# Concat MCS mask files
+ncrcat -O -v time,longitude,latitude,tb,precipitation,cloudtracknumber,feature_number \
+  ${out_dirname}mcstrack*.nc ${out_dirname}${out_filename}
+
+# Rename variables
+ncrename -v cloudtracknumber,MCS_objects -v tb,Tb -v precipitation,PR -v feature_number,BT_objects ${out_dirname}${out_filename}
+
+# Rename dimensions
+ncrename -d lat,yc -d lon,xc ${out_dirname}${out_filename}
+
+echo ${out_dirname}${out_filename}

--- a/config/config_mcs_idealized.yml
+++ b/config/config_mcs_idealized.yml
@@ -23,7 +23,7 @@ timeout: 360  # [seconds] Dask timeout limit
 
 # Start/end date and time
 startdate: '20200101.0000'
-enddate: '20200102.0000'
+enddate: '20200103.0000'
 
 # Specify tracking input data date/time string format
 # This is the preprocessed file that contains Tb & rainrate
@@ -86,9 +86,9 @@ pf_link_area_thresh:  648.0  # [km^2]
 # Tracking parameters
 othresh: 0.5  # overlap fraction threshold. Clouds that overlap more than this between times are tracked.
 timegap: 3.1  # [hour] If missing data duration longer than this, tracking restarts
-nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
-maxnclouds: 3000  # Maximum number of clouds in one snapshot
-duration_range: [2, 400] # A vector [minlength,maxlength] to specify the duration range for the tracks
+nmaxlinks: 10  # Maximum number of clouds that any single cloud can be linked to
+maxnclouds: 10  # Maximum number of clouds in one snapshot
+duration_range: [2, 100] # A vector [minlength,maxlength] to specify the duration range for the tracks
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/demo_mcs_tbpf_idealized.sh
+++ b/config/demo_mcs_tbpf_idealized.sh
@@ -12,11 +12,11 @@
 
 # Specify directory for the demo data
 # There are a total of 4 tests (e.g., test1, test2, test3, test4)
-dir_demo='/Users/feng045/data/demo/mcs_tbpf/idealized/test2/'
+dir_demo='/Users/feng045/data/demo/mcs_tbpf/idealized/test4/'
 
 # Test input file basename
 # There are a total of 4 tests (e.g., 'MCS-test-1_', 'MCS-test-2_', etc.)
-data_basename='MCS-test-2_'
+data_basename='MCS-test-4_'
 
 # Example config file name
 config_demo='config_mcs_demo.yml'
@@ -56,7 +56,7 @@ echo 'Tracking is done.'
 # Make quicklook plots
 echo 'Making quicklook plots ...'
 quicklook_dir=${dir_demo}'/quicklooks_trackpaths/'
-python ../Analysis/plot_subset_tbpf_mcs_tracks_demo.py -s '2020-01-01T00' -e '2020-01-02T00' \
+python ../Analysis/plot_subset_tbpf_mcs_tracks_demo.py -s '2020-01-01T00' -e '2020-01-03T00' \
     -c ${config_demo} -o vertical -p 1 --figsize 10 8 --output ${quicklook_dir}
 echo 'View quicklook plots here: '${quicklook_dir}
 

--- a/pyflextrkr/identifymcs.py
+++ b/pyflextrkr/identifymcs.py
@@ -178,7 +178,7 @@ def identifymcs_tb(config):
             mergetrack_idx = mergetrack_idx[trackstat_lifetime[mergetrack_idx] < merge_duration]
 
             # Make sure the merge tracks are not MCS
-            mergetrack_idx = mergetrack_idx[np.isin(mergetrack_idx, mcstracknumbers, invert=True)]
+            mergetrack_idx = mergetrack_idx[np.isin(mergetrack_idx, trackidx_mcs, invert=True)]
             if len(mergetrack_idx) > 0:
                 # Get data for merging tracks
                 mergingcloudnumber = cloudnumbers[mergetrack_idx, :].data
@@ -216,7 +216,7 @@ def identifymcs_tb(config):
             splittrack_idx = splittrack_idx[trackstat_lifetime[splittrack_idx] < split_duration]
 
             # Make sure the split tracks are not MCS
-            splittrack_idx = splittrack_idx[np.isin(splittrack_idx, mcstracknumbers, invert=True)]
+            splittrack_idx = splittrack_idx[np.isin(splittrack_idx, trackidx_mcs, invert=True)]
             if len(splittrack_idx) > 0:
                 # Get data for split tracks
                 splittingcloudnumber = cloudnumbers[splittrack_idx, :].data


### PR DESCRIPTION
1. Fixed a bug in identifymcs.py. Some small merge/split clouds with MCSs might be missed in previous version because MCS track indices that should be excluded when finding merge/split clouds (line 181, 219) were off by 1.
2. Updated idealized MCS tracking config and demo script to include all times in the input data: demo_mcs_tbpf_idealized.sh, config_mcs_idealized.yml.
3. Added a new bash script to combine the idealized MCS tracking mask files to a single file: concat_mcs_idealized_masks.sh.