### PR TITLE
Cumulative updates in December 2023.

### DIFF
--- a/config/config_scream_mcs_tbradar_15min_template.yml
+++ b/config/config_scream_mcs_tbradar_15min_template.yml
@@ -32,16 +32,17 @@ time_format: 'yyyymoddThhmmss'
 databasename: 'obs_v4_2_'
 
 # Tracking input files directory
-clouddata_path: '/pscratch/sd/j/jli628/15min/CASE/'
+clouddata_path: '/pscratch/sd/f/feng045/HyperFACETS/derecho/scream_15min/FORCING/tb_radar/CASE/'
 # Working directory for the tracking data
-root_path: '/pscratch/sd/f/feng045/HyperFACETS/derecho/scream_15min/CASE/'
+root_path: '/pscratch/sd/f/feng045/HyperFACETS/derecho/scream_15min/FORCING/CASE/'
 # Working sub-directory names
 tracking_path_name: 'tracking'
 stats_path_name: 'stats'
 pixel_path_name: 'mcstracking'
 
 # Land mask file
-landmask_filename: '/global/cfs/cdirs/m2637/zfeng/derecho/scream/map_data/ocean_mask.nc'
+# landmask_filename: '/global/cfs/cdirs/m2637/zfeng/derecho/scream/map_data/ocean_mask.nc'
+landmask_filename: '/pscratch/sd/f/feng045/HyperFACETS/derecho/scream_15min/maps/cean_mask.nc'
 landmask_varname: 'mask'
 landmask_x_dimname: 'lon'
 landmask_y_dimname: 'lat'

--- a/pyflextrkr/identifymcs.py
+++ b/pyflextrkr/identifymcs.py
@@ -114,7 +114,7 @@ def identifymcs_tb(config):
 
             # System may have multiple periods satisfying area and duration requirements
             # Loop over each period
-            if iccs != []:
+            if len(iccs) > 0:
                 for t in range(0, nbreaks):
                     # Duration requirement
                     # Duration length should be group's last index - first index + 1

--- a/slurm/slurm_scream_mcs_tbradar_template.sh
+++ b/slurm/slurm_scream_mcs_tbradar_template.sh
@@ -7,7 +7,7 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=64
 #SBATCH --exclusive
-#SBATCH --output=log_scream_mcs_CASE.log
+#SBATCH --output=log_scream_mcs_CASE_FORCING.log
 #SBATCH --mail-type=END
 #SBATCH --mail-user=zhe.feng@pnnl.gov
 
@@ -18,6 +18,6 @@ source activate /global/common/software/m1867/python/pyflex
 
 # Run Python
 cd /global/homes/f/feng045/program/PyFLEXTRKR-dev/runscripts
-python run_mcs_tbpfradar3d.py /global/homes/f/feng045/program/PyFLEXTRKR-dev/config/config_scream_mcs_CASE.yml
+python run_mcs_tbpfradar3d.py /global/homes/f/feng045/program/PyFLEXTRKR-dev/config/config_scream_mcs_CASE_FORCING.yml
 
 date


### PR DESCRIPTION
1. Fixed an old syntax issue in identifymcs.py (line 117).
2. Added a new option to specify a list of variable names in the config when regridding the MCS tracking masks from the coarsen grid back to the native input grid in regrid_tracking_mask.py.
3. Updated /Analysis/plot_subset_tbpf_mcs_tracks_demo.py to automatically calculate appropriate aspect ratio based on the lat/lon extent of the plotting region if figsize is not specified.
4. Added a new quicklook plot script to plot Tb+PF MCS tracking on a single panel: /Analysis/plot_subset_tbpf_mcs_tracks_1panel_demo.py