### PR TITLE
changes focused on GPM IMERG

### DIFF
--- a/Analysis/plot_subset_tbpf_mcs_tracks_demo.py
+++ b/Analysis/plot_subset_tbpf_mcs_tracks_demo.py
@@ -1,7 +1,7 @@
 """
 Demonstrates ploting MCS tracks on Tb, precipitation snapshots for a subset domain.
 
->python plot_subset_tbpf_mcs_tracks_demo.py -s STARTDATE -e ENDDATE -c CONFIG.yml -o horizontal 
+>python plot_subset_tbpf_mcs_tracks_demo.py -s STARTDATE -e ENDDATE -c CONFIG.yml -o horizontal
 Optional arguments:
 -p 0 (serial), 1 (parallel)
 --extent lonmin lonmax latmin latmax (subset domain boundary)
@@ -90,8 +90,8 @@ def make_dilation_structure(dilate_radius, dx, dy):
         dx: float
             Grid spacing in x-direction [kilometer].
         dy: float
-            Grid spacing in y-direction [kilometer]. 
-    
+            Grid spacing in y-direction [kilometer].
+
     Returns:
         struc: np.array
             Dilation structure array.
@@ -130,7 +130,7 @@ def label_perimeter(tracknumber, dilationstructure):
 
 #-----------------------------------------------------------------------
 def truncate_colormap(cmap, minval=0.0, maxval=1.0, n=256):
-    """ 
+    """
     Truncate colormap.
     """
     new_cmap = mpl.colors.LinearSegmentedColormap.from_list(
@@ -152,7 +152,7 @@ def get_track_stats(trackstats_file, start_datetime, end_datetime, dt_thres):
             End datetime to subset tracks.
         dt_thres: timedelta
             A timedelta threshold to retain tracks.
-            
+
     Returns:
         track_dict: dictionary
             Dictionary containing track stats data.
@@ -170,7 +170,7 @@ def get_track_stats(trackstats_file, start_datetime, end_datetime, dt_thres):
     ntracks = len(idx)
     print(f'Number of tracks within input period: {ntracks}')
 
-    # Subset these tracks and put in a dictionary    
+    # Subset these tracks and put in a dictionary
     track_dict = {
         'ntracks': ntracks,
         'lifetime': dss['track_duration'].isel(tracks=idx) * time_res,
@@ -183,7 +183,7 @@ def get_track_stats(trackstats_file, start_datetime, end_datetime, dt_thres):
         'dt_thres': dt_thres,
         'time_res': time_res,
     }
-    
+
     return track_dict
 
 #-----------------------------------------------------------------------
@@ -200,12 +200,12 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
             Dictionary containing map boundary info.
         track_dict: dictionary
             Dictionary containing tracking data variables.
-            
+
     Returns:
         fig: object
             Figure handle.
     """
-        
+
     # Get pixel data from dictionary
     lon = pixel_dict['lon']
     lat = pixel_dict['lat']
@@ -228,7 +228,7 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
     # Get plot info from dictionary
     levels = plot_info['levels']
     cmaps = plot_info['cmaps']
-    titles = plot_info['titles'] 
+    titles = plot_info['titles']
     cblabels = plot_info['cblabels']
     cbticks = plot_info['cbticks']
     fontsize = plot_info['fontsize']
@@ -253,10 +253,10 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
     latv = map_info.get('latv', None)
     draw_border = map_info.get('draw_border', False)
     draw_state = map_info.get('draw_state', False)
-            
+
     # Time difference matching pixel-time and track time
     dt_match = 1  # [min]
-    
+
     # Marker style for tracks
     marker_style = dict(edgecolor=trackpath_color, facecolor=trackpath_color, linestyle='-', marker='o')
 
@@ -269,7 +269,7 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
 
     # Set up figure
     mpl.rcParams['font.size'] = fontsize
-    mpl.rcParams['font.family'] = 'Helvetica'
+    mpl.rcParams['font.family'] = 'Trebuchet MS'#'Helvetica'
     fig = plt.figure(figsize=figsize, dpi=dpi, facecolor='w')
     # vertical: left + right panel
     if panel_orientation == 'vertical':
@@ -306,7 +306,7 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
         gl.xlocator = mpl.ticker.FixedLocator(lonv)
         gl.ylocator = mpl.ticker.FixedLocator(latv)
     lon_formatter = LongitudeFormatter(zero_direction_label=True)
-    lat_formatter = LatitudeFormatter()        
+    lat_formatter = LatitudeFormatter()
     ax1.xaxis.set_major_formatter(lon_formatter)
     ax1.yaxis.set_major_formatter(lat_formatter)
 
@@ -326,7 +326,7 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
     # Tb Colorbar
     cb1 = plt.colorbar(cf1, cax=cax1, label=cblabels['tb_label'], ticks=cbticks['tb_ticks'],
                        extend='both', orientation=cb_orientation)
-    
+
     #################################################################
     # Precipitation Panel
     ax2.set_extent(map_extent, crs=data_proj)
@@ -358,7 +358,7 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
     # cm1 = ax2.pcolormesh(lon, lat, tracknumber_masked, norm=norm, cmap=cmap, transform=data_proj, zorder=2, alpha=0.7)
     cm1 = ax2.pcolormesh(lon, lat, tracknumber_masked, vmin=min(levels['tn_levels']), vmax=max(levels['tn_levels']),
                          cmap=cmap, transform=data_proj, zorder=2, alpha=0.7)
-    
+
     # Precipitation
     cmap = plt.get_cmap(cmaps['pcp_cmap'])
     norm = mpl.colors.BoundaryNorm(levels['pcp_levels'], ncolors=cmap.N, clip=True)
@@ -368,7 +368,7 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
     cax2 = plt.subplot(gs[1,1])
     cb2 = plt.colorbar(cf2, cax=cax2, label=cblabels['pcp_label'], ticks=cbticks['pcp_ticks'],
                        extend='both', orientation=cb_orientation)
-    
+
     #################################################################
     # Plot track centroids and paths
     for itrack in range(0, ntracks):
@@ -376,7 +376,7 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
         ilifetime = lifetime.data[itrack]
         itracknum = lifetime.tracks.data[itrack]+1
         idur = (ilifetime / time_res).astype(int)
-        idiam = track_pf_diam.data[itrack,:idur]       
+        idiam = track_pf_diam.data[itrack,:idur]
         # Get basetime of the track and the track end time
         ibt = track_bt.data[itrack,:idur]
         ibt_end = np.nanmax(ibt)
@@ -402,7 +402,7 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
                                   transform=data_proj, zorder=4, **marker_style)
                 cl2 = ax2.scatter(track_ccs_lon.data[itrack,0], track_ccs_lat.data[itrack,0], s=marker_size*2,
                                   transform=data_proj, zorder=4, **marker_style)
-                
+
         # Find the closest time from track times
         idt = np.abs((ibt - pixel_bt).astype('timedelta64[m]'))
         idx_match = np.argmin(idt)
@@ -426,7 +426,7 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
                          ha='left', va='center', weight='bold', transform=data_proj, zorder=5)
                 ax2.text(_iccslon+0.05, _iccslat+0.05, f'{itracknum:.0f}', color='k', size=tracknumber_fontsize, 
                          ha='left', va='center', weight='bold', transform=data_proj, zorder=5)
-    
+
     # Custom legend for track paths
     legend_elements1 = [
         mpl.lines.Line2D([0], [0], color=trackpath_color, marker='o', lw=trackpath_linewidth, label='MCS Tracks'),
@@ -440,16 +440,16 @@ def plot_map_2panels(pixel_dict, plot_info, map_info, track_dict):
     ]
     ax1.legend(handles=legend_elements1, loc='lower right')
     ax2.legend(handles=legend_elements2, loc='lower right')
-    
+
     # Thread-safe figure output
     canvas = FigureCanvas(fig)
     canvas.print_png(figname)
     fig.savefig(figname)
-    
+
     return fig
 
 #-----------------------------------------------------------------------
-def work_for_time_loop(datafile, track_dict, map_info, plot_info, config):
+def work_for_time_loop(datafile, track_dict, map_info, plot_info, config, ifile):
     """
     Work with a pixel-level file.
 
@@ -464,9 +464,9 @@ def work_for_time_loop(datafile, track_dict, map_info, plot_info, config):
             Directory name for figures.
         figbasename: string, optional, default=''
             Base name for figures.
-            
+
     Returns:
-        1: success.            
+        1: success.
     """
 
     map_extent = map_info.get('map_extent', None)
@@ -509,7 +509,7 @@ def work_for_time_loop(datafile, track_dict, map_info, plot_info, config):
         # Add to plot_info dictionary
         plot_info['levels']['tn_levels'] = tn_levels
 
-        # Subset pixel data within the map domain        
+        # Subset pixel data within the map domain
         if subset == 1:
             lonmin, lonmax = map_extent[0], map_extent[1]
             latmin, latmax = map_extent[2], map_extent[3]
@@ -528,12 +528,12 @@ def work_for_time_loop(datafile, track_dict, map_info, plot_info, config):
             lat_sub = ds['latitude']
         # Get object perimeters
         tn_perim = label_perimeter(tracknumber_sub.data, dilationstructure)
-        
+
         # Plotting variables
         fdatetime = pd.to_datetime(ds['time'].data.item()).strftime('%Y%m%d_%H%M%S')
         timestr = pd.to_datetime(ds['time'].data.item()).strftime('%Y-%m-%d %H:%M:%S UTC')
-        figname = f'{figdir}{figbasename}{fdatetime}.png'
-
+        # figname = f'{figdir}{figbasename}{fdatetime}.png'
+        figname = f'{figdir}image{"{:05d}".format(ifile+1)}.png'
         # Put pixel data in a dictionary
         pixel_dict = {
             'lon': lon_sub,
@@ -604,7 +604,7 @@ if __name__ == "__main__":
     cbticks = {'tb_ticks': tb_ticks, 'pcp_ticks': pcp_ticks}
     cblabels = {'tb_label': 'Tb (K)', 'pcp_label': 'Precipitation (mm h$^{-1}$)'}
     # Colormap
-    tb_cmap = truncate_colormap(plt.get_cmap('jet'), minval=0.05, maxval=0.95)
+    tb_cmap = truncate_colormap(plt.get_cmap('turbo'), minval=0.05, maxval=0.95)#'jet'
     pcp_cmap = truncate_colormap(plt.get_cmap('viridis'), minval=0.2, maxval=1.0)
     tn_cmap = cc.cm["glasbey_light"]
     # tn_cmap = cc.cm["glasbey"]
@@ -681,7 +681,7 @@ if __name__ == "__main__":
     # These are for searching pixel-level files
     start_basetime = pd.to_datetime(start_datetime).timestamp()
     end_basetime = pd.to_datetime(end_datetime).timestamp()
-    # Subtract start_datetime by TimeDelta to include tracks 
+    # Subtract start_datetime by TimeDelta to include tracks
     # that start before the start_datetime but may not have ended yet
     TimeDelta = pd.Timedelta(days=4)
     start_datetime_4stats = (pd.to_datetime(start_datetime) - TimeDelta).strftime('%Y-%m-%dT%H')
@@ -707,7 +707,7 @@ if __name__ == "__main__":
         for ifile in range(len(datafiles)):
             print(datafiles[ifile])
             result = work_for_time_loop(
-                datafiles[ifile], track_dict, map_info, plot_info, config,
+                datafiles[ifile], track_dict, map_info, plot_info, config, ifile,
             )
 
     # Parallel option
@@ -722,7 +722,7 @@ if __name__ == "__main__":
         for ifile in range(len(datafiles)):
             print(datafiles[ifile])
             result = dask.delayed(work_for_time_loop)(
-                datafiles[ifile], track_dict, map_info, plot_info, config,
+                datafiles[ifile], track_dict, map_info, plot_info, config, ifile,
             )
             results.append(result)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Use the included environment.yml file to create a Conda virtual environment, mak
 conda env create -f environment.yml --prefix /conda_env_dir/flextrkr
 ```
 
+or ...
+
+```bash
+conda create -n flextrkr -c conda-forge --file requirements.txt
+```
+
 **Pro Tips:** using [mamba](https://anaconda.org/conda-forge/mamba) to create the virtual environment is much faster:
 
 ```bash

--- a/config/demo_mcs_imerg.sh
+++ b/config/demo_mcs_imerg.sh
@@ -42,6 +42,12 @@ echo 'Created new config file: '${config_demo}
 
 # Activate PyFLEXTRKR conda environment
 echo 'Activating PyFLEXTRKR environment ...'
+# sourcing conda
+case $(uname -s) in
+	'Linux')     echo "LinUx" && . $HOME/miniconda3/etc/profile.d/conda.sh;;
+	'Darwin')    echo "Mac" && . $HOME/miniconda3/etc/profile.d/conda.sh;;
+        *);;
+esac
 conda activate flextrkr
 
 # Run tracking
@@ -58,7 +64,7 @@ echo 'View quicklook plots here: '${quicklook_dir}
 
 # Make animation using ffmpeg
 echo 'Making animations from quicklook plots ...'
-ffmpeg -framerate 2 -pattern_type glob -i ${quicklook_dir}'*.png' -c:v libx264 -r 10 -crf 20 -pix_fmt yuv420p \
+ffmpeg -framerate 2 -pattern_type sequence -start_number 00001 -i ${quicklook_dir}'image%05d.png' -c:v libx264 -r 10 -crf 20 -pix_fmt yuv420p \
     -y ${quicklook_dir}quicklook_animation.mp4
 echo 'View animation here: '${quicklook_dir}quicklook_animation.mp4
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,8 @@
-name: base
+name: flextrkr
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python>=3.10
   - numpy>=1.17
   - matplotlib>=3
   - xarray>=0.14

--- a/pyflextrkr/ft_utilities.py
+++ b/pyflextrkr/ft_utilities.py
@@ -417,6 +417,9 @@ def subset_ds_geolimit(
     }
     # Subset dataset
     ds_out = ds_in[subset_dict]
+    # transpose coordinates to enesure LAT is always the 1st dimension
+    ds_out = ds_out.transpose(y_dimname,x_dimname)
+    # ds_out = ds_out.transpose(y_coordname,x_coordname) # maybe?
     return ds_out
 
 def match_drift_times(
@@ -514,8 +517,8 @@ def load_sparse_trackstats(
                              decode_times=False)
     # Get sparse array info
     sparse_dimname = 'sparse_index'
-    nsparse_data = ds_all.dims[sparse_dimname]
-    ntracks = ds_all.dims[tracks_dimname]
+    nsparse_data = ds_all.sizes[sparse_dimname]
+    ntracks = ds_all.sizes[tracks_dimname]
     # Sparse array indices
     tracks_idx = ds_all[tracks_idx_varname].values
     times_idx = ds_all[times_idx_varname].values
@@ -585,8 +588,8 @@ def convert_trackstats_sparse2dense(
     )
     # Get sparse array info
     sparse_dimname = 'sparse_index'
-    nsparse_data = ds_all.dims[sparse_dimname]
-    ntracks = ds_all.dims[tracks_dimname]
+    nsparse_data = ds_all.sizes[sparse_dimname]
+    ntracks = ds_all.sizes[tracks_dimname]
     # Sparse array indices
     tracks_idx = ds_all[tracks_idx_varname].values
     times_idx = ds_all[times_idx_varname].values

--- a/pyflextrkr/gettracks.py
+++ b/pyflextrkr/gettracks.py
@@ -608,7 +608,7 @@ def gettracknumbers(config):
     # Define output variables dictionary
     var_dict = {
         "ntracks": (["time"], np.array([itrack])),
-        "basetimes": (["nfiles"], basetime[:nfiles]),
+        "basetimes": (["nfiles"], basetime[:nfiles].astype("datetime64[ns]")),
         "cloudid_files": (["nfiles", "ncharacters"], cloudidfiles[:nfiles,:]),
         "track_numbers": (["time", "nfiles", "nclouds"], tracknumber[:,:nfiles,:]),
         "track_status": (["time", "nfiles", "nclouds"], trackstatus[:,:nfiles,:].astype(int)),

--- a/pyflextrkr/identifymcs.py
+++ b/pyflextrkr/identifymcs.py
@@ -60,7 +60,7 @@ def identifymcs_tb(config):
                                          tracks_idx_varname)
 
     # Get necessary variables
-    ntracks_all = ds_1d.dims[tracks_dimname]
+    ntracks_all = ds_1d.sizes[tracks_dimname]
     logger.debug(f"max_trackduration: {max_trackduration}")
     track_duration = ds_1d["track_duration"].values
     end_merge_tracknumber = ds_1d["end_merge_tracknumber"].values
@@ -135,7 +135,7 @@ def identifymcs_tb(config):
 
     ################################################################
     # Get unique track indices
-    trackidx_mcs = np.unique(trackidx_mcs.astype(int))
+    trackidx_mcs = np.unique(np.asarray(trackidx_mcs).astype(int))
     nmcs = len(trackidx_mcs)
     # Provide warning message and exit if no MCS identified
     if nmcs == 0:

--- a/pyflextrkr/mapfeature_func.py
+++ b/pyflextrkr/mapfeature_func.py
@@ -74,8 +74,8 @@ def map_feature(
         mask_and_scale=False
     )
     # Get data dimensions
-    ny = ds_in.dims[y_dimname]
-    nx = ds_in.dims[x_dimname]
+    ny = ds_in.sizes[y_dimname]
+    nx = ds_in.sizes[x_dimname]
     # Get dimension names from the file
     dims_file = []
     for key in ds_in.dims: dims_file.append(key)

--- a/pyflextrkr/matchtbpf_driver.py
+++ b/pyflextrkr/matchtbpf_driver.py
@@ -63,8 +63,8 @@ def match_tbpf_tracks(config):
     ds = xr.open_dataset(mcsirstats_file,
                          mask_and_scale=False,
                          decode_times=False)
-    ir_ntracks = ds.dims[tracks_dimname]
-    ir_nmaxlength = ds.dims[times_dimname]
+    ir_ntracks = ds.sizes[tracks_dimname]
+    ir_nmaxlength = ds.sizes[times_dimname]
     ir_basetime = ds["base_time"].values
     ir_cloudnumber = ds["cloudnumber"].values
     ir_mergecloudnumber = ds["merge_cloudnumber"].values

--- a/pyflextrkr/robustmcspf.py
+++ b/pyflextrkr/robustmcspf.py
@@ -52,8 +52,8 @@ def define_robust_mcs_pf(config):
     ds_pf = xr.open_dataset(mcspfstats_file,
                             mask_and_scale=False,
                             decode_times=False,)
-    ntracks = ds_pf.dims[tracks_dimname]
-    ntimes = ds_pf.dims[times_dimname]
+    ntracks = ds_pf.sizes[tracks_dimname]
+    ntimes = ds_pf.sizes[times_dimname]
 
     ir_trackduration = ds_pf["track_duration"].data
     pf_area = ds_pf["pf_area"].data

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,12 @@ joblib>=0.14
 ipython>=7.0
 setuptools>=65.5.1
 PyYAML>=5.4
+pip
+astropy
+wrf-python
+colorcet
+colormath
+seaborn
+scikit-learn
+ffmpeg
+xesmf

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 with open('requirements.txt') as f:


### PR DESCRIPTION
as suggested by the title, the changes submitted in this pull-request are main focus on the scripts pertaining to tracking using GPM IMERG Tb + precipitationCal.

the following is a brief description of (most of) the suggested changes:

1. *README.md* now offers an alternative on how to install PyFLEXTRKR via ```conda``` from the *requirements.txt* file.
2. explicit 'utf-8' encoding in the *setup.py* file. check [this](https://stackoverflow.com/a/50709581/5885810) out, for instance.
(there was some evidence of the library/package developed on Linux (and not tested in WOS, for instance; this helps now to run PyFLEXTRKR 'seamlessly' in WOS.)
3. instead of using date-times in the names of png-outputs from the *plot_subset_tbpf_mcs_tracks_demo.py*, not their names follow an ordinal pattern, e.g., "image00001.png". this allows for the *demo_mcs_imerg.sh* file (last step) to produce the movie from those png-files. as suggested by [this post](https://stackoverflow.com/questions/31201164/ffmpeg-error-pattern-type-glob-was-selected-but-globbing-is-not-support-ed-by/31513542#31513542), ```-pattern_type glob``` is not available in WOS; but the now ```-pattern_type sequence``` allows the generation of movies both in Linux and WOS.
(because this implementation was only applied to the 'imerg-demo', most likely all other demos will still be incompatible for WOS.) 
4. 'turbo' may be a better alternative than 'jet' (especially for colorblind people) in *plot_subset_tbpf_mcs_tracks_demo.py*.
5. all the instances (again, only in GPM IMERG-related files) of 'dims' in ```xarray``` objects, e.g., "ds_in.dims[...]" were replaced to  "ds_in.sizes[...]". this to avoid the "FutureWarning: The return type of `Dataset.dims` will be...".
(PyFLEXTRKR also runs in ```python=3.11.7``` (both Linux and Windows). this might enable too supporting later versions of ```xarray```, which was probably the cause of the aforementioned warning.)
6. the "UserWarning: Converting non-nanosecond precision datetime values to nanosecond precision..." was also taken care of.
(```basetime[:nfiles].astype("datetime64[ns]")``` in line 611 of *gettracks.py*)
7. how the coordinates are arranged at the end of function "subset_ds_geolimit" (in *ft_utilities.py*) allows now to simply apply (and rightly retrieve the lat-lon order) of land-sea masks downloaded from [GES DISC](https://disc.gsfc.nasa.gov/datasets/GPM_IMERG_LandSeaMask_2/summary?keywords=imerg).
(as it was before, PyFLEXTRKR crashed in pf-rain fraction over land and sea, because the "shape" of the ```numpy```, i.e., lat-lon was transposed).
8. a new approach of movement direction (e.g., in *movement_speed.py*) was implemented. now 0/360 (degrees) is for north, 90 for east, 180 for south, and 270 for west. when computing x-y vectors from this angles, sines are cosines work just fine. if the pf/feature is not moving, the angle/direction is ```nan``` (that is, when the movement speed is zero). also the speed now is not interpolated (which previously caused having unrealistic zero or nan speeds).
(please see the snapshot below to have a look on how the direction/speed has been changed. top row is old approach; bottom row is new approach; left column is for speeds; right column is for directions.)
![movement_improved](https://github.com/FlexTRKR/PyFLEXTRKR/assets/28873952/339db52e-e0d7-4c9a-9b48-b6ead892e9fd)