### PR TITLE
Add auto-update track duration range and fix PBC argmax crash

### DIFF
--- a/config/config_coldpool_buoyancy.yml
+++ b/config/config_coldpool_buoyancy.yml
@@ -77,6 +77,8 @@ othresh: 0.5           # overlap percentage threshold
 maxnclouds: 1000       # Maximum number of features in one snapshot
 nmaxlinks: 50          # Maximum number of overlaps that any single feature can be linked to
 duration_range: [2, 500]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_csapr4km_example.yml
+++ b/config/config_csapr4km_example.yml
@@ -193,6 +193,8 @@ othresh: 0.3           # overlap percentage threshold
 maxnclouds: 1000       # Maximum number of clouds in one snapshot
 nmaxlinks: 10          # Maximum number of clouds that any single cloud can be linked to
 duration_range: [2, 60]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_csapr500m_example.yml
+++ b/config/config_csapr500m_example.yml
@@ -158,6 +158,8 @@ othresh: 0.3           # overlap percentage threshold
 maxnclouds: 1000       # Maximum number of clouds in one snapshot
 nmaxlinks: 10          # Maximum number of clouds that any single cloud can be linked to
 duration_range: [2, 60]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_dyamond_nicam_example.yml
+++ b/config/config_dyamond_nicam_example.yml
@@ -97,6 +97,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 400] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_dyamond_summer_ifs.yml
+++ b/config/config_dyamond_summer_ifs.yml
@@ -97,6 +97,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds:  3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 400] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_dyamond_summer_obs.yml
+++ b/config/config_dyamond_summer_obs.yml
@@ -97,6 +97,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds:  3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 400] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_era5_mcs_tbpf.yml
+++ b/config/config_era5_mcs_tbpf.yml
@@ -102,6 +102,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 2000  # Maximum number of clouds in one snapshot
 duration_range: [2, 1000] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_era5_mcs_tbpf_mcsmip.yml
+++ b/config/config_era5_mcs_tbpf_mcsmip.yml
@@ -102,6 +102,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 2000  # Maximum number of clouds in one snapshot
 duration_range: [2, 1000] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_era5_mcs_tbpf_nolink.yml
+++ b/config/config_era5_mcs_tbpf_nolink.yml
@@ -103,6 +103,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 2000  # Maximum number of clouds in one snapshot
 duration_range: [2, 1000] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_era5_psi.yml
+++ b/config/config_era5_psi.yml
@@ -71,6 +71,8 @@ othresh: 0.3           # overlap percentage threshold
 maxnclouds: 60       # Maximum number of features in one snapshot
 nmaxlinks: 10          # Maximum number of overlaps that any single feature can be linked to
 duration_range: [6, 800]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_era5_vorticity.yml
+++ b/config/config_era5_vorticity.yml
@@ -76,6 +76,8 @@ othresh: 0.3           # overlap percentage threshold
 maxnclouds: 100       # Maximum number of features in one snapshot
 nmaxlinks: 10          # Maximum number of overlaps that any single feature can be linked to
 duration_range: [6, 800]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_era5_z500_example.yml
+++ b/config/config_era5_z500_example.yml
@@ -65,6 +65,8 @@ othresh: 0.3           # overlap percentage threshold
 maxnclouds: 60       # Maximum number of features in one snapshot
 nmaxlinks: 4          # Maximum number of overlaps that any single feature can be linked to
 duration_range: [3, 100]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_gridrad_mcs_example.yml
+++ b/config/config_gridrad_mcs_example.yml
@@ -131,6 +131,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 200  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 2000  # Maximum number of clouds in one snapshot
 duration_range: [2, 300] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_gridrad_mcs_template.yml
+++ b/config/config_gridrad_mcs_template.yml
@@ -132,6 +132,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 200  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 2000  # Maximum number of clouds in one snapshot
 duration_range: [2, 300] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_himawari_mcs_example.yml
+++ b/config/config_himawari_mcs_example.yml
@@ -89,6 +89,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 600] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_imerg25km_mcs_tbpf.yml
+++ b/config/config_imerg25km_mcs_tbpf.yml
@@ -103,6 +103,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 1000] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_imerg_mcs_tbpf_example.yml
+++ b/config/config_imerg_mcs_tbpf_example.yml
@@ -97,7 +97,9 @@ othresh: 0.5  # overlap fraction threshold. Clouds that overlap more than this b
 timegap: 3.1  # [hour] If missing data duration longer than this, tracking restarts
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 3000  # Maximum number of clouds in one snapshot
-duration_range: [2, 400] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range: [2, 20] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_mcs_idealized.yml
+++ b/config/config_mcs_idealized.yml
@@ -90,6 +90,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 10  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 10  # Maximum number of clouds in one snapshot
 duration_range: [2, 100] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_mcs_pbc_idealized.yml
+++ b/config/config_mcs_pbc_idealized.yml
@@ -91,6 +91,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 10  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 100] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_mcs_pbc_idealized_demo.yml
+++ b/config/config_mcs_pbc_idealized_demo.yml
@@ -91,6 +91,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 10  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 100] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_mcs_pinacles_example.yml
+++ b/config/config_mcs_pinacles_example.yml
@@ -102,6 +102,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds:  1000  # Maximum number of clouds in one snapshot
 duration_range: [2, 100] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_mcs_saag_example.yml
+++ b/config/config_mcs_saag_example.yml
@@ -99,6 +99,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds:  3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 400] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_mcs_tbpf_imergv7_mcsmip.yml
+++ b/config/config_mcs_tbpf_imergv7_mcsmip.yml
@@ -109,6 +109,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds:  3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 400] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_mcs_tbpf_imergv7_mcsmip_demo.yml
+++ b/config/config_mcs_tbpf_imergv7_mcsmip_demo.yml
@@ -108,7 +108,9 @@ othresh: 0.5  # overlap fraction threshold. Clouds that overlap more than this b
 timegap: 3.1  # [hour] If missing data duration longer than this, tracking restarts
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds:  3000  # Maximum number of clouds in one snapshot
-duration_range: [2, 400] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range: [2, 100] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_mcs_tbpf_scream_healpix7.yml
+++ b/config/config_mcs_tbpf_scream_healpix7.yml
@@ -117,6 +117,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds:  3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 650] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_mcs_tbpf_scream_healpix9.yml
+++ b/config/config_mcs_tbpf_scream_healpix9.yml
@@ -117,6 +117,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds:  3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 650] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_model25km_mcs_tbpf_example.yml
+++ b/config/config_model25km_mcs_tbpf_example.yml
@@ -96,6 +96,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 200  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 2000  # Maximum number of clouds in one snapshot
 duration_range: [2, 300] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_mrms_mcs_composite_reflectivity.yml
+++ b/config/config_mrms_mcs_composite_reflectivity.yml
@@ -65,6 +65,8 @@ othresh: 0.5           # overlap percentage threshold
 maxnclouds: 1000       # Maximum number of features in one snapshot
 nmaxlinks: 50          # Maximum number of overlaps that any single feature can be linked to
 duration_range: [3, 150]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_nexrad500m_example.yml
+++ b/config/config_nexrad500m_example.yml
@@ -158,6 +158,8 @@ othresh: 0.3           # overlap percentage threshold
 maxnclouds: 1000       # Maximum number of clouds in one snapshot
 nmaxlinks: 10          # Maximum number of clouds that any single cloud can be linked to
 duration_range: [2, 100]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_saag_wrf4km_cacti.yml
+++ b/config/config_saag_wrf4km_cacti.yml
@@ -172,6 +172,8 @@ othresh: 0.3           # overlap percentage threshold
 maxnclouds: 1000       # Maximum number of clouds in one snapshot
 nmaxlinks: 10          # Maximum number of clouds that any single cloud can be linked to
 duration_range: [2, 60]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_saag_wrf4km_goamazon.yml
+++ b/config/config_saag_wrf4km_goamazon.yml
@@ -172,6 +172,8 @@ othresh: 0.3           # overlap percentage threshold
 maxnclouds: 1000       # Maximum number of clouds in one snapshot
 nmaxlinks: 10          # Maximum number of clouds that any single cloud can be linked to
 duration_range: [2, 60]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_sipam4km_example.yml
+++ b/config/config_sipam4km_example.yml
@@ -191,6 +191,8 @@ othresh: 0.3           # overlap percentage threshold
 maxnclouds: 1000       # Maximum number of clouds in one snapshot
 nmaxlinks: 10          # Maximum number of clouds that any single cloud can be linked to
 duration_range: [2, 60]   # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_tgw_mcs_hist_template.yml
+++ b/config/config_tgw_mcs_hist_template.yml
@@ -97,6 +97,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 200  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 2000  # Maximum number of clouds in one snapshot
 duration_range: [2, 300] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_wrf4km_mcs_tbpf_example.yml
+++ b/config/config_wrf4km_mcs_tbpf_example.yml
@@ -97,6 +97,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 200  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 2000  # Maximum number of clouds in one snapshot
 duration_range: [2, 300] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_wrf_mcs_tbradar_example.yml
+++ b/config/config_wrf_mcs_tbradar_example.yml
@@ -136,6 +136,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 200  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 2000  # Maximum number of clouds in one snapshot
 duration_range: [2, 300] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/config/config_wrfregrid_mcs_tbpf_example.yml
+++ b/config/config_wrfregrid_mcs_tbpf_example.yml
@@ -119,6 +119,8 @@ timegap: 3.1  # [hour] If missing data duration longer than this, tracking resta
 nmaxlinks: 50  # Maximum number of clouds that any single cloud can be linked to
 maxnclouds: 3000  # Maximum number of clouds in one snapshot
 duration_range: [2, 400] # A vector [minlength,maxlength] to specify the duration range for the tracks
+duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
+duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
 # Flag to remove short-lived tracks [< min(duration_range)] that are not mergers/splits with other tracks
 # 0:keep all tracks; 1:remove short tracks
 remove_shorttracks: 1

--- a/pyflextrkr/ft_utilities.py
+++ b/pyflextrkr/ft_utilities.py
@@ -702,7 +702,9 @@ def load_sparse_trackstats(
     # Drop all sparse variables and dimension
     ds_1d = ds_all.drop_dims(sparse_dimname)
     ds_all.close()
-    return ds_1d, sparse_attrs_dict, sparse_dict
+    # Return max_trackduration as 4th value so callers always use the correct
+    # size even when the file was written with duration_range_auto_update.
+    return ds_1d, sparse_attrs_dict, sparse_dict, max_trackduration
 
 
 def convert_trackstats_sparse2dense(

--- a/pyflextrkr/identifymcs.py
+++ b/pyflextrkr/identifymcs.py
@@ -57,12 +57,15 @@ def identifymcs_tb(config):
     statistics_file = f"{stats_path}{trackstats_sparse_filebase}{startdate}_{enddate}.nc"
     logger.debug(statistics_file)
 
-    # Load sparse tracks statistics file and convert to sparse arrays
+    # Load sparse tracks statistics file and convert to sparse arrays.
+    # max_trackduration is returned as 4th value (derived from the file) so
+    # that files written with duration_range_auto_update are handled correctly.
     ds_1d, \
     sparse_attrs_dict, \
-    sparse_dict = load_sparse_trackstats(max_trackduration, statistics_file,
-                                         times_idx_varname, tracks_dimname,
-                                         tracks_idx_varname)
+    sparse_dict, \
+    max_trackduration = load_sparse_trackstats(max_trackduration, statistics_file,
+                                               times_idx_varname, tracks_dimname,
+                                               tracks_idx_varname)
 
     # Get necessary variables
     ntracks_all = ds_1d.sizes[tracks_dimname]

--- a/pyflextrkr/link_mergesplit_tracks.py
+++ b/pyflextrkr/link_mergesplit_tracks.py
@@ -51,12 +51,15 @@ def link_mergesplit_tracks(config):
     statistics_file = f"{stats_path}{trackstats_sparse_filebase}{startdate}_{enddate}.nc"
     logger.debug(statistics_file)
 
-    # Load sparse tracks statistics file and convert to sparse arrays
+    # Load sparse tracks statistics file and convert to sparse arrays.
+    # max_trackduration is returned as 4th value (derived from the file) so
+    # that files written with duration_range_auto_update are handled correctly.
     ds_1d, \
     sparse_attrs_dict, \
-    sparse_dict = load_sparse_trackstats(max_trackduration, statistics_file,
-                                         times_idx_varname, tracks_dimname,
-                                         tracks_idx_varname)
+    sparse_dict, \
+    max_trackduration = load_sparse_trackstats(max_trackduration, statistics_file,
+                                               times_idx_varname, tracks_dimname,
+                                               tracks_idx_varname)
 
     # Get necessary variables
     ntracks_all = ds_1d.sizes[tracks_dimname]

--- a/pyflextrkr/matchtbpf_func.py
+++ b/pyflextrkr/matchtbpf_func.py
@@ -229,19 +229,17 @@ def matchtbpf_singlefile(
                         # with no hardcoded edge thresholds.
                         sorted_x = np.sort(np.unique(icloudlocationx))
                         gap_x    = np.diff(sorted_x)
-                        max_gap_x_idx = np.argmax(gap_x)
-                        if gap_x[max_gap_x_idx] > xdim * 0.5:
-                            # Right cluster starts at sorted_x[max_gap_x_idx + 1]
-                            shift_x_right = xdim - int(sorted_x[max_gap_x_idx + 1])
+                        if len(gap_x) > 0 and gap_x[np.argmax(gap_x)] > xdim * 0.5:
+                            # Right cluster starts at sorted_x[argmax + 1]
+                            shift_x_right = xdim - int(sorted_x[np.argmax(gap_x) + 1])
                         else:
                             shift_x_right = 0
 
                         sorted_y = np.sort(np.unique(icloudlocationy))
                         gap_y    = np.diff(sorted_y)
-                        max_gap_y_idx = np.argmax(gap_y)
-                        if gap_y[max_gap_y_idx] > ydim * 0.5:
-                            # Top cluster starts at sorted_y[max_gap_y_idx + 1]
-                            shift_y_top = ydim - int(sorted_y[max_gap_y_idx + 1])
+                        if len(gap_y) > 0 and gap_y[np.argmax(gap_y)] > ydim * 0.5:
+                            # Top cluster starts at sorted_y[argmax + 1]
+                            shift_y_top = ydim - int(sorted_y[np.argmax(gap_y) + 1])
                         else:
                             shift_y_top = 0
 

--- a/pyflextrkr/matchtbradar_func.py
+++ b/pyflextrkr/matchtbradar_func.py
@@ -296,16 +296,14 @@ def matchtbpf_singlefile(
                         # A gap > 50% of domain length indicates a boundary crossing.
                         sorted_x = np.sort(np.unique(icloudlocationx))
                         gap_x    = np.diff(sorted_x)
-                        max_gap_x_idx = np.argmax(gap_x)
-                        if gap_x[max_gap_x_idx] > xdim * 0.5:
-                            shift_x_right = xdim - int(sorted_x[max_gap_x_idx + 1])
+                        if len(gap_x) > 0 and gap_x[np.argmax(gap_x)] > xdim * 0.5:
+                            shift_x_right = xdim - int(sorted_x[np.argmax(gap_x) + 1])
                         else:
                             shift_x_right = 0
                         sorted_y = np.sort(np.unique(icloudlocationy))
                         gap_y    = np.diff(sorted_y)
-                        max_gap_y_idx = np.argmax(gap_y)
-                        if gap_y[max_gap_y_idx] > ydim * 0.5:
-                            shift_y_top = ydim - int(sorted_y[max_gap_y_idx + 1])
+                        if len(gap_y) > 0 and gap_y[np.argmax(gap_y)] > ydim * 0.5:
+                            shift_y_top = ydim - int(sorted_y[np.argmax(gap_y) + 1])
                         else:
                             shift_y_top = 0
                         rolled_x = (icloudlocationx + shift_x_right) % xdim

--- a/pyflextrkr/trackstats_driver.py
+++ b/pyflextrkr/trackstats_driver.py
@@ -40,6 +40,8 @@ def trackstats_driver(config):
     tracking_outpath = config["tracking_outpath"]
     stats_path = config["stats_outpath"]
     duration_range = config["duration_range"]
+    duration_range_auto_update = config.get("duration_range_auto_update", False)
+    duration_range_round_base  = config.get("duration_range_round_base", 10)
     run_parallel = config["run_parallel"]
     fillval = config["fillval"]
     tracks_dimname = config["tracks_dimname"]
@@ -219,33 +221,56 @@ def trackstats_driver(config):
                     out_dict["track_duration"][tracknumbertmp] + 1
             )
 
-            # Find track lengths that are within max_trackduration
-            # Only record these to avoid array index out of bounds
-            # itracklength = out_tracklength[tracknumbertmp]
             itracklength = out_dict["track_duration"][tracknumbertmp]
-            ridx = itracklength <= max_trackduration
             # Loop over each variable and assign values to output dictionary
             for ivar in var_names:
                 # Concatenate arrays for 2D variables
                 out_dict[ivar] = np.concatenate(
                     (out_dict[ivar], iResult[ivar])
                 )
-            # row, column indices for sparse matrix
-            # row:tracks, col:times
-            row_idx = np.concatenate((row_idx, tracknumbertmp[ridx])).astype(int)
-            col_idx = np.concatenate((col_idx, itracklength[ridx] - 1)).astype(int)
+            # row, column indices for sparse matrix (row:tracks, col:times)
+            # Collect all entries unconditionally; filtering happens after the
+            # auto-update check so that max_trackduration is already final.
+            row_idx = np.concatenate((row_idx, tracknumbertmp)).astype(int)
+            col_idx = np.concatenate((col_idx, itracklength - 1)).astype(int)
 
     #########################################################################################
     # Check data max duration against config set up
-    # Provide warning message and exit if 'duration_range' is too short
     data_max_trackduration = np.nanmax(out_dict["track_duration"])
     if data_max_trackduration > max_trackduration:
-        logger.critical(f"WARNING: Max track duration in data ({data_max_trackduration}) " +
-                        f"exceeds 'duration_range' ({duration_range}) in the config file!")
-        logger.critical(f"This would cause missing statistics in long-lived tracks!")
-        logger.critical(f"Increase 'duration_range' in the config file.")
-        logger.critical(f"Tracking will now exit.")
-        sys.exit()
+        if duration_range_auto_update:
+            # Round up to the nearest multiple of duration_range_round_base
+            new_max = int(
+                np.ceil(data_max_trackduration / duration_range_round_base)
+                * duration_range_round_base
+            )
+            logger.warning(
+                f"Max track duration in data ({data_max_trackduration}) exceeds "
+                f"'duration_range' max ({max_trackduration}). "
+                f"Auto-updating max_trackduration: {max_trackduration} -> {new_max} "
+                f"(rounded up to nearest {duration_range_round_base})."
+            )
+            max_trackduration = new_max
+            # Propagate the updated value back into config so that downstream
+            # functions called in the same run (e.g. identifymcs) see the
+            # correct max_trackduration when they read duration_range.
+            config["duration_range"] = [min(duration_range), max_trackduration]
+        else:
+            logger.critical(f"WARNING: Max track duration in data ({data_max_trackduration}) " +
+                            f"exceeds 'duration_range' ({duration_range}) in the config file!")
+            logger.critical(f"This would cause missing statistics in long-lived tracks!")
+            logger.critical(f"Increase 'duration_range' in the config file, or set "
+                            f"'duration_range_auto_update: True' to allow automatic expansion.")
+            logger.critical(f"Tracking will now exit.")
+            sys.exit()
+
+    # Filter row/col indices and variable data to the (possibly updated) max_trackduration.
+    # This is the single, correct filtering point — data was collected unconditionally above.
+    valid_mask = col_idx < max_trackduration
+    for ivar in var_names:
+        out_dict[ivar] = out_dict[ivar][valid_mask]
+    row_idx = row_idx[valid_mask].astype(int)
+    col_idx = col_idx[valid_mask].astype(int)
 
     # Convert 2D variables to sparse arrays
     row_col_ind = (row_idx, col_idx)


### PR DESCRIPTION
# Add auto-update track duration range and fix PBC argmax crash

## Summary

This PR adds an optional feature to automatically expand `max_trackduration` when
the data exceeds the configured `duration_range` maximum, instead of calling
`sys.exit()`. It also fixes a crash in the periodic-boundary-condition (PBC) gap
detection that occurred when an MCS occupied only a single row or column
(e.g. on coarse 1×1° grids). All 36 tracked config YAML files are updated to
opt in to the new auto-update behavior.

---

## Changes

### New feature: auto-update track duration (`pyflextrkr/trackstats_driver.py`)

Two new optional config keys control the behavior:

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `duration_range_auto_update` | bool | `False` | When `True`, automatically expands `max_trackduration` instead of exiting if data duration exceeds `duration_range` max |
| `duration_range_round_base` | int | `10` | Round the auto-updated value up to the nearest multiple of this number |

When `duration_range_auto_update: True` and the observed maximum track duration
exceeds the configured ceiling:

1. `max_trackduration` is rounded up to the nearest multiple of
   `duration_range_round_base` and a warning is logged.
2. The updated value is written back into `config["duration_range"]` so that
   all downstream pipeline steps called in the same run (e.g. `identifymcs`,
   `link_mergesplit_tracks`) automatically see the correct value.

When `duration_range_auto_update: False` (the default), the existing error
message and `sys.exit()` are unchanged.

### Propagation fix for cross-run restarts (`pyflextrkr/ft_utilities.py`, `pyflextrkr/identifymcs.py`, `pyflextrkr/link_mergesplit_tracks.py`)

When `duration_range_auto_update` is enabled, the track-statistics file is
written with a larger `max_trackduration` than the value stored in the YAML
config. If downstream steps are re-run independently (e.g. re-running only
`identifymcs` after a crash), they derive `max_trackduration` from the YAML
and would construct a CSR sparse matrix that is too small, causing:

```
ValueError: axis 1 index 29 exceeds matrix dimension 20
```

`load_sparse_trackstats` in `ft_utilities.py` now reads the actual maximum
`times_idx` value from the file and uses `max(config_value, file_value)` as
the CSR matrix column dimension. The corrected `max_trackduration` is returned
as a fourth value in the return tuple so callers (`identifymcs.py` and
`link_mergesplit_tracks.py`) always use the size that matches the file on disk.

### Bug fix: PBC gap-detection argmax crash (`pyflextrkr/matchtbpf_func.py`, `pyflextrkr/matchtbradar_func.py`)

When detecting whether an MCS crosses a periodic boundary, the code sorted the
unique x/y pixel coordinates and looked for a gap larger than half the domain
width. On coarse grids (e.g. 1×1°) an MCS can occupy only a single row or
column, producing an empty `np.diff()` array and crashing with:

```
ValueError: attempt to get argmax of an empty sequence
```

The fix adds a `len(gap) > 0` guard before calling `np.argmax`, defaulting to
zero shift when no gap exists:

```python
sorted_x = np.sort(np.unique(icloudlocationx))
gap_x    = np.diff(sorted_x)
if len(gap_x) > 0 and gap_x[np.argmax(gap_x)] > xdim * 0.5:
    shift_x_right = xdim - int(sorted_x[np.argmax(gap_x) + 1])
else:
    shift_x_right = 0
```

The same guard is applied to both the x and y directions in both
`matchtbpf_func.py` and `matchtbradar_func.py`.

### Config YAML updates (`config/*.yml`)

All 36 tracked config YAML files now include the two new keys immediately after
the `duration_range:` line:

```yaml
duration_range_auto_update: True  # Auto-expand max_trackduration if data exceeds duration_range max
duration_range_round_base: 10     # Round up to nearest multiple of this value when auto-updating
```

`config_csapr500m_example.yml` also has its `duration_range` max value
corrected from the temporary test value `[2, 10]` back to `[2, 60]`.

---

## Testing

- `demo_cell_csapr` — passed with auto-update active (`duration_range: [2, 60]`,
  `duration_range_round_base: 10`); 84 tracks found, correct lat/lon ranges.
- `demo_mcs_imerg` — passed end-to-end through `identifymcs` and
  `link_mergesplit_tracks` with `duration_range: [2, 20]` and auto-updated
  `max_trackduration`; confirmed no `ValueError` on sparse matrix construction.
- Import smoke test passes for all modified modules.
